### PR TITLE
Consider empty requestBody as valid if not required

### DIFF
--- a/src/PSR7/Exception/Validation/InvalidBody.php
+++ b/src/PSR7/Exception/Validation/InvalidBody.php
@@ -46,4 +46,12 @@ class InvalidBody extends AddressValidationFailed
 
         return $exception;
     }
+
+    public static function becauseOfMissingRequiredBody(OperationAddress $addr): self
+    {
+        $exception          = static::fromAddr($addr);
+        $exception->message = sprintf('Required body is missing for %s', $addr);
+
+        return $exception;
+    }
 }

--- a/src/PSR7/SpecFinder.php
+++ b/src/PSR7/SpecFinder.php
@@ -7,15 +7,14 @@ namespace League\OpenAPIValidation\PSR7;
 use cebe\openapi\exceptions\TypeErrorException;
 use cebe\openapi\spec\Callback;
 use cebe\openapi\spec\Header as HeaderSpec;
-use cebe\openapi\spec\MediaType;
 use cebe\openapi\spec\OpenApi;
 use cebe\openapi\spec\Operation;
 use cebe\openapi\spec\Parameter;
 use cebe\openapi\spec\PathItem;
-use cebe\openapi\spec\Reference;
 use cebe\openapi\spec\Response as ResponseSpec;
 use cebe\openapi\spec\SecurityRequirement;
 use cebe\openapi\spec\SecurityScheme;
+use cebe\openapi\SpecBaseObject;
 use League\OpenAPIValidation\PSR7\Exception\NoCallback;
 use League\OpenAPIValidation\PSR7\Exception\NoOperation;
 use League\OpenAPIValidation\PSR7\Exception\NoPath;
@@ -171,23 +170,15 @@ final class SpecFinder
     }
 
     /**
-     * @return MediaType[]|Reference[]
-     *
      * @throws NoPath
      */
-    public function findBodySpec(OperationAddress $addr): array
+    public function findBodySpec(OperationAddress $addr): ?SpecBaseObject
     {
         if ($addr instanceof ResponseAddress || $addr instanceof CallbackResponseAddress) {
-            return $this->findResponseSpec($addr)->content;
+            return $this->findResponseSpec($addr);
         }
 
-        $requestBody = $this->findOperationSpec($addr)->requestBody;
-
-        if (! $requestBody) {
-            return [];
-        }
-
-        return $requestBody->content;
+        return $this->findOperationSpec($addr)->requestBody;
     }
 
     /**

--- a/tests/FromCommunity/OptionalRequestBodyTest.php
+++ b/tests/FromCommunity/OptionalRequestBodyTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\OpenAPIValidation\Tests\FromCommunity;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use League\OpenAPIValidation\PSR7\Exception\Validation\InvalidBody;
+use League\OpenAPIValidation\PSR7\ValidatorBuilder;
+use PHPUnit\Framework\TestCase;
+
+class OptionalRequestBodyTest extends TestCase
+{
+    public function testOptionalEmptyBodyIsValid(): void
+    {
+        $yaml = /** @lang yaml */
+            <<<'YAML'
+openapi: 3.0.0
+info:
+  title: Test API
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8000'
+paths:
+  /api:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+      responses:
+        '204':
+          description: No content
+YAML;
+
+        $validator = (new ValidatorBuilder())->fromYaml($yaml)->getServerRequestValidator();
+
+        $validator->validate(
+            new ServerRequest(
+                'POST',
+                '/api'
+            )
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testRequiredEmptyBodyThrowsException(): void
+    {
+        $yaml = /** @lang yaml */
+            <<<'YAML'
+openapi: 3.0.0
+info:
+  title: Test API
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8000'
+paths:
+  /api:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+      responses:
+        '204':
+          description: No content
+YAML;
+
+        $validator = (new ValidatorBuilder())->fromYaml($yaml)->getServerRequestValidator();
+
+        $this->expectException(InvalidBody::class);
+        $this->expectExceptionMessage('Required body is missing for Request [post /api]');
+        $validator->validate(
+            new ServerRequest(
+                'POST',
+                '/api'
+            )
+        );
+    }
+}


### PR DESCRIPTION
In the OpenApi specification, [request bodies are optional by default](https://swagger.io/docs/specification/describing-request-body/), unless `required: true` is declared explicitly.

So I think the BodyValidator should not throw an exception in case an **optional** request body is not provided in the request.

As well, if a requestBody is required in the spec but not provided in the request, we can directly throw an InvalidBody exception and not try to validate against the schema.

One consequence is that projects using the library might need to add `required: true` on their endpoints in order to keep the same validation behaviour.